### PR TITLE
Rename to Rocket.Chat instead of Rocket.Chat+

### DIFF
--- a/chat.rocket.RocketChat.appdata.xml
+++ b/chat.rocket.RocketChat.appdata.xml
@@ -15,7 +15,7 @@
   </description>
   <screenshots>
     <screenshot type="default">
-      <image type="source">https://rocket.chat/images/index/devices@2x.png</image>
+      <image type="source">https://rocket.chat/images/index/devices.png</image>
     </screenshot>
   </screenshots>
   <releases>

--- a/chat.rocket.RocketChat.appdata.xml
+++ b/chat.rocket.RocketChat.appdata.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop">
   <id>chat.rocket.RocketChat.desktop</id>
-  <name>Rocket.Chat+</name>
+  <name>Rocket.Chat</name>
   <project_license>MIT</project_license>
   <developer_name>Rocket.Chat</developer_name>
   <summary>Open Source Team Communication</summary>


### PR DESCRIPTION
All apps are called just Rocket.Chat now across all platforms.  So adjusting flathub listing to match

