### PR TITLE
Update to v2.15.5

### DIFF
--- a/chat.rocket.RocketChat.appdata.xml
+++ b/chat.rocket.RocketChat.appdata.xml
@@ -19,6 +19,8 @@
     </screenshot>
   </screenshots>
   <releases>
+    <release version="2.15.5" date="2019-08-09"/>
+    <release version="2.15.4" date="2019-08-09"/>
     <release version="2.15.3" date="2019-04-30"/>
     <release version="2.15.2" date="2019-04-16"/>
     <release version="2.15.1" date="2019-03-13"/>

--- a/chat.rocket.RocketChat.json
+++ b/chat.rocket.RocketChat.json
@@ -34,19 +34,13 @@
                 {
                     "type": "file",
                     "only-arches": ["x86_64"],
-                    "url": "https://github.com/RocketChat/Rocket.Chat.Electron/releases/download/2.15.3/rocketchat_2.15.3_amd64.deb",
-                    "sha256": "1a09d31301c0b2e81b1fff29fc6c4eb163588d86160fc5bb4190dd88a7ca2274"
+                    "url": "https://github.com/RocketChat/Rocket.Chat.Electron/releases/download/2.15.5/rocketchat_2.15.5_amd64.deb",
+                    "sha256": "839ed2eaba5fb7887b630cc83c7afd595830239b31936a661ec534ddcb4e5a37"
                 },
                 {
                     "type": "file",
-                    "only-arches": ["i386"],
-                    "url": "https://github.com/RocketChat/Rocket.Chat.Electron/releases/download/2.15.3/rocketchat_2.15.3_i386.deb",
-                    "sha256": "04e57b5244e1202cec057c246f0e22c45d1bff2e32f589e908972fa6b74fe882"
-                },
-                {
-                    "type": "file",
-                    "url": "https://github.com/RocketChat/Rocket.Chat.Electron/archive/2.15.3.tar.gz",
-                    "sha256": "9e7a5e66e65312bc71358873e1583de841b9142c91d835876da001d0bb2e4f65"
+                    "url": "https://github.com/RocketChat/Rocket.Chat.Electron/archive/2.15.5.tar.gz",
+                    "sha256": "1155942888e4737ff4f1932daef80255ac94e106e6931b1892eacc2e1f32e806"
                 },
                 {
                     "type": "script",

--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,3 @@
 {
-  "only-arches": ["x86_64", "i386"]
+  "only-arches": ["x86_64"]
 }


### PR DESCRIPTION
Unfortunately, upstream removed i386 builds, and the overhead to provide built-from-source packages is just too high now (with the whole dependency pinning thing), so from now on, only x86_64 builds.

If anyone finds a simpler way to get an Electron package with tons of deps easily built and updateable in flatpak, I'll be glad to review PRs.