### PR TITLE
Update to v3.8.3

### DIFF
--- a/chat.rocket.RocketChat.appdata.xml
+++ b/chat.rocket.RocketChat.appdata.xml
@@ -21,6 +21,7 @@
     </screenshot>
   </screenshots>
   <releases>
+    <release version="3.8.3" date="2022-04-14"/>
     <release version="3.8.2" date="2022-04-05"/>
     <release version="3.8.1" date="2022-03-29"/>
     <release version="3.8.0" date="2022-03-18"/>

--- a/chat.rocket.RocketChat.json
+++ b/chat.rocket.RocketChat.json
@@ -34,13 +34,13 @@
                 {
                     "type": "file",
                     "only-arches": ["x86_64"],
-                    "url": "https://github.com/RocketChat/Rocket.Chat.Electron/releases/download/3.8.2/rocketchat-3.8.2-linux-amd64.deb",
-                    "sha256": "6a91142c3dec4d05a0c9a68c38dab12fe649967cba37c3f2c4ec83dcc1ce4b08"
+                    "url": "https://github.com/RocketChat/Rocket.Chat.Electron/releases/download/3.8.3/rocketchat-3.8.3-linux-amd64.deb",
+                    "sha256": "728e34fec59cfcc2bc6ebcceb454f7b1edc18d4630b1d7c7324bee0f384aa5fc"
                 },
                 {
                     "type": "file",
-                    "url": "https://github.com/RocketChat/Rocket.Chat.Electron/archive/refs/tags/3.8.2.tar.gz",
-                    "sha256": "e31a4024249843584545f7a2a5b060a36c86cbd6b24d9b270eff4afd34ce7d9c"
+                    "url": "https://github.com/RocketChat/Rocket.Chat.Electron/archive/refs/tags/3.8.3.tar.gz",
+                    "sha256": "4b2b4c4a142585500aeb617455d034839cbf8d3768d8dbbdeb0d7b7079afe115"
                 },
                 {
                     "type": "script",


### PR DESCRIPTION
This version comes with Electron v18, which includes native portal support, and wayland.
To enable it, add `--ozone-playform=wayland` to your command line, either by running it directly (e.g. `flatpak run chat.rocket.RocketChat --ozone-platform=wayland`) or by copying `.desktop` file to your `~/.local/share/applications` and editing `Exec` entry.