### PR TITLE
Update to v3.9.7

### DIFF
--- a/chat.rocket.RocketChat.appdata.xml
+++ b/chat.rocket.RocketChat.appdata.xml
@@ -21,6 +21,7 @@
     </screenshot>
   </screenshots>
   <releases>
+    <release version="3.9.7" date="2023-09-25"/>
     <release version="3.9.6" date="2023-08-04"/>
     <release version="3.9.5" date="2023-06-19"/>
     <release version="3.9.4" date="2023-05-18"/>

--- a/chat.rocket.RocketChat.json
+++ b/chat.rocket.RocketChat.json
@@ -34,13 +34,13 @@
                 {
                     "type": "file",
                     "only-arches": ["x86_64"],
-                    "url": "https://github.com/RocketChat/Rocket.Chat.Electron/releases/download/3.9.6/rocketchat-3.9.6-linux-amd64.deb",
-                    "sha256": "0cce75c78c055545929d78e8ccc210c997ce02ed5b7e9d212a8db8e66e390985"
+                    "url": "https://github.com/RocketChat/Rocket.Chat.Electron/releases/download/3.9.7/rocketchat-3.9.7-linux-amd64.deb",
+                    "sha256": "0f163c71758705ba07e948768bd0d227617cfce6864d194811a2f3850a579ca9"
                 },
                 {
                     "type": "file",
-                    "url": "https://github.com/RocketChat/Rocket.Chat.Electron/archive/refs/tags/3.9.6.tar.gz",
-                    "sha256": "975e328c97c7db5718a641c8efd9f9022b8abcef2f04ea8ca388bc5d0074b56d"
+                    "url": "https://github.com/RocketChat/Rocket.Chat.Electron/archive/refs/tags/3.9.7.tar.gz",
+                    "sha256": "cfb2dac5ad6ef2c3740e0333e6fff9ef80e93d846b370e1d9ad205960eed9f03"
                 },
                 {
                     "type": "script",


### PR DESCRIPTION
This has a fix that makes copying to clipboard links work again