### PR TITLE
Runtime: downgrade from 23.08 to 22.08

### DIFF
--- a/chat.rocket.RocketChat.yaml
+++ b/chat.rocket.RocketChat.yaml
@@ -1,8 +1,8 @@
 app-id: chat.rocket.RocketChat
 runtime: org.freedesktop.Platform
-runtime-version: '23.08'
+runtime-version: '22.08'
 base: org.electronjs.Electron2.BaseApp
-base-version: '23.08'
+base-version: '22.08'
 sdk: org.freedesktop.Sdk
 command: rocketchat-desktop
 separate-locales: false


### PR DESCRIPTION
https://github.com/flathub/chat.rocket.RocketChat/pull/115#issuecomment-1736158842
> Seems the upgrade to the new runtime broke things. Now when notifications happen the whole application crashes. When I down grade back to my commit right before it stops happening