### PR TITLE
Drop `org.kde.*` own-name

### DIFF
--- a/chat.rocket.RocketChat.yaml
+++ b/chat.rocket.RocketChat.yaml
@@ -27,8 +27,6 @@ finish-args:
   - --talk-name=org.freedesktop.portal.Background
   # Allow advanced input methods
   - --talk-name=org.freedesktop.portal.Fcitx
-  # This is needed for the tray icon
-  - --own-name=org.kde.*
 modules:
   - name: rocketchat-desktop
     buildsystem: simple


### PR DESCRIPTION
This is no longer required with newer Electron and runtime

https://docs.flatpak.org/en/latest/desktop-integration.html#statusnotifier

> Most implementations of StatusNotifer have dropped this requirement
> but known exceptions to this are Electron versions older than 23.3.0.

Current version uses Electron 24.8.3
https://github.com/RocketChat/Rocket.Chat.Electron/blob/df33261ee8c70e4db5623af8bfa8aae8b1a01535/package.json#L114