### PR TITLE
Drop notifications talk-name

### DIFF
--- a/chat.rocket.RocketChat.yaml
+++ b/chat.rocket.RocketChat.yaml
@@ -16,8 +16,6 @@ finish-args:
   - --share=network
   # Camera for calls
   - --device=all
-  # We need to send notifications
-  - --talk-name=org.freedesktop.Notifications
   - --talk-name=org.gnome.Mutter.IdleMonitor
   - --talk-name=org.kde.StatusNotifierWatcher
   - --talk-name=com.canonical.AppMenu.Registrar


### PR DESCRIPTION
Electron 23.08 baseapp comes with libnotify 0.8 which uses the portal to show notifications

https://gitlab.gnome.org/GNOME/libnotify/-/blob/69aff6e5fa2842e00b409c348bd73188548828b3/NEWS#L25