### PR TITLE
Revert to runtime to avoid crash

### DIFF
--- a/chat.rocket.RocketChat.yaml
+++ b/chat.rocket.RocketChat.yaml
@@ -16,6 +16,7 @@ finish-args:
   - --share=network
   # Camera for calls
   - --device=all
+  - --talk-name=org.freedesktop.Notifications
   - --talk-name=org.gnome.Mutter.IdleMonitor
   - --talk-name=org.kde.StatusNotifierWatcher
   - --talk-name=com.canonical.AppMenu.Registrar

--- a/chat.rocket.RocketChat.yaml
+++ b/chat.rocket.RocketChat.yaml
@@ -1,8 +1,8 @@
 app-id: chat.rocket.RocketChat
 runtime: org.freedesktop.Platform
-runtime-version: '23.08'
+runtime-version: '22.08'
 base: org.electronjs.Electron2.BaseApp
-base-version: '23.08'
+base-version: '22.08'
 sdk: org.freedesktop.Sdk
 command: rocketchat-desktop
 separate-locales: false


### PR DESCRIPTION
Just like #116 was proposing to do.  Take runtime version back down so the app is usable again in flatpak. Currently due to #122  and #121 its unusable.

Only way to get it working is by downgrading to the commit before this runtime was upgraded: 
```
sudo flatpak update --commit=d9f7d7691360809521895f20f6164705150054957f64df411868a9f66e527acc chat.rocket.RocketChat
```

I've had to do this several times.  Trying to avoid doing this and masking to prevent the update